### PR TITLE
Homework 3: Streams

### DIFF
--- a/css/a.css
+++ b/css/a.css
@@ -1,0 +1,3 @@
+.a {
+  font-size: 13px;
+}

--- a/css/b.css
+++ b/css/b.css
@@ -1,0 +1,3 @@
+.b {
+  font-size: 14px;
+}

--- a/css/c.css
+++ b/css/c.css
@@ -1,0 +1,3 @@
+.c {
+  font-size: 15px;
+}

--- a/css/readme.md
+++ b/css/readme.md
@@ -1,0 +1,1 @@
+css files should be combined to `bundle.css`

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Anton Telesh <anton_telesh@epam.com>",
   "license": "MIT",
   "dependencies": {
+    "JSONStream": "^1.3.1",
     "csv-parse": "^1.2.2",
     "eventemitter3": "^2.0.3",
     "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
   "dependencies": {
     "csv-parse": "^1.2.2",
     "eventemitter3": "^2.0.3",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "request": "^2.83.0",
+    "split": "^1.0.1",
+    "through2": "^2.0.3",
+    "yargs": "^9.0.1"
   },
   "devDependencies": {
     "babel": "^6.23.0",

--- a/utils/streams.js
+++ b/utils/streams.js
@@ -3,6 +3,8 @@
 const yargs = require('yargs')
 const fs = require('fs')
 const path = require('path')
+const throught2 = require('through2')
+const parse = require('csv-parse')
 
 const isCLI = require.main === module
 
@@ -10,32 +12,68 @@ const inputOutput = (_path) =>
   fs.createReadStream(path.relative(process.cwd(), _path))
     .pipe(process.stdout)
 
-const perform = ({ action, path }) => {
-  switch (action) {
-    case 'io': return inputOutput(path)
-    default: throw new Error(`Unknown action "${action}"`)
-  }
-}
+const transformFile = (_path) =>
+  fs.createReadStream(path.relative(process.cwd(), _path))
+    .pipe(parse({
+      columns: true,
+    }))
+    .pipe(throught2.obj(function (chunk, enc, cb) {
+      this.push(JSON.stringify(chunk, null, 2))
+      cb()
+    }))
+    .pipe(process.stdout)
 
 const argv = yargs
   .options({
-    'a': {
-      alias: 'action',
-      choices: [ 'io', 'transform-file', 'transform', 'bundle-css' ],
-      describe: 'An action to perform',
-      demandOption: true,
-    },
-    'p': {
-      alias: 'path',
-      describe: 'An action to perform',
-      demandOption: true,
-    },
-    'h': {
-      alias: 'help',
+    'help': {
+      alias: 'h'
     },
   })
+  .command(
+    'io',
+    'Read the file',
+    {
+      file: {
+        alias: 'f',
+        describe: 'path to the file',
+        normalize: true,
+        demandOption: true,
+      },
+    },
+    (argv) => inputOutput(argv.file)
+  )
+  .command(
+    'transform-file',
+    'Parse CSV file as JSON',
+    {
+      file: {
+        alias: 'f',
+        describe: 'path to the file',
+        normalize: true,
+        demandOption: true,
+      },
+    },
+    (argv) => transformFile(argv.file)
+  )
+  .command(
+    'transform',
+    'Parse CSV input as JSON',
+    {},
+    () => transform()
+  )
+  .command(
+    'bundle-css',
+    'Bundles all css files in the folder into one file',
+    {
+      path: {
+        alias: 'p',
+        describe: 'directory with css files to bundle',
+        normalize: true,
+        demandOption: true,
+      }
+    },
+    (argv) => bundleCss(path)
+  )
   .locale('en')
   .version(false)
   .argv
-
-perform(argv)

--- a/utils/streams.js
+++ b/utils/streams.js
@@ -23,6 +23,17 @@ const transformFile = (_path) =>
     }))
     .pipe(process.stdout)
 
+const transform = () =>
+  process.stdin
+    .pipe(parse({
+      columns: true,
+    }))
+    .pipe(throught2.obj(function (chunk, enc, cb) {
+      this.push(JSON.stringify(chunk, null, 2))
+      cb()
+    }))
+    .pipe(process.stdout)
+
 const argv = yargs
   .options({
     'help': {

--- a/utils/streams.js
+++ b/utils/streams.js
@@ -115,9 +115,12 @@ const argv = yargs
     },
     (argv) => bundleCss(argv.path)
   )
+  .demandCommand(1, 'You need at least one command before moving on')
   .locale('en')
   .version(false)
   .argv
+
+console.log(argv)
 
 module.exports = {
   inputOutput,

--- a/utils/streams.js
+++ b/utils/streams.js
@@ -1,8 +1,21 @@
 #!/usr/bin/env node
 
 const yargs = require('yargs')
+const fs = require('fs')
+const path = require('path')
 
 const isCLI = require.main === module
+
+const inputOutput = (_path) =>
+  fs.createReadStream(path.relative(process.cwd(), _path))
+    .pipe(process.stdout)
+
+const perform = ({ action, path }) => {
+  switch (action) {
+    case 'io': return inputOutput(path)
+    default: throw new Error(`Unknown action "${action}"`)
+  }
+}
 
 const argv = yargs
   .options({
@@ -25,4 +38,4 @@ const argv = yargs
   .version(false)
   .argv
 
-console.log(argv)
+perform(argv)

--- a/utils/streams.js
+++ b/utils/streams.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const yargs = require('yargs')
+
+const isCLI = require.main === module
+
+const argv = yargs
+  .options({
+    'a': {
+      alias: 'action',
+      choices: [ 'io', 'transform-file', 'transform', 'bundle-css' ],
+      describe: 'An action to perform',
+      demandOption: true,
+    },
+    'p': {
+      alias: 'path',
+      describe: 'An action to perform',
+      demandOption: true,
+    },
+    'h': {
+      alias: 'help',
+    },
+  })
+  .locale('en')
+  .version(false)
+  .argv
+
+console.log(argv)


### PR DESCRIPTION
Implements slightly better API than described in requirements.
Uses command as an action to perform instead of option parameter.

# CLI Usage

### Help:

```
$ ./utils/streams.js --help
```

### Read file

```
$ ./utils/streams.js io --file ./path/to/file
```

### Transform CSV to JSON inline

```
$ cat data/MOCK_DATA.csv | ./utils/streams.js transform
```

### Convert CSV file into JSON file

```
$ ./utils/streams.js transform-file --file ./data/MOCK_DATA.csv
```

### Bundle all css files in a directory

```
$ ./utils/streams.js bundle-css --path ./css
```